### PR TITLE
Add MultiParamTypeClasses pragma to Links example

### DIFF
--- a/book/chapters/basics.asciidoc
+++ b/book/chapters/basics.asciidoc
@@ -233,6 +233,7 @@ take a look:
 {-# LANGUAGE QuasiQuotes           #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 import           Yesod
 
 data Links = Links


### PR DESCRIPTION
Add the LANGUAGE pragma 'MultiParamTypeClasses' to the Links example. Otherwise ghc will not compile:

test_links.hs:11:1:
    Illegal instance declaration for `YesodDispatch Links Links'
      (Only one type can be given in an instance head.
       Use -XMultiParamTypeClasses if you want to allow more.)
    In the instance declaration for`YesodDispatch Links Links'
