### PR TITLE
hamletToRepHtml -> giveUrlRenderer

### DIFF
--- a/book/chapters/yesod-typeclass.asciidoc
+++ b/book/chapters/yesod-typeclass.asciidoc
@@ -262,7 +262,7 @@ instance Yesod App where
     defaultLayout contents = do
         PageContent title headTags bodyTags <- widgetToPageContent contents
         mmsg <- getMessage
-        hamletToRepHtml [hamlet|
+        giveUrlRenderer [hamlet|
             $doctype 5
 
             <html>


### PR DESCRIPTION
Since it's recommended by Yesod itself:

In the use of `hamletToRepHtml'
    (imported from Yesod, but defined in Yesod.Core.Handler):
    Deprecated: "Use giveUrlRenderer instead"
