### PR TITLE
persistent: first example needs EmptyDataDecls

### DIFF
--- a/book/chapters/persistent.asciidoc
+++ b/book/chapters/persistent.asciidoc
@@ -44,6 +44,7 @@ Persistent on its own.
 
 [source, haskell]
 ----
+{-# LANGUAGE EmptyDataDecls    #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}


### PR DESCRIPTION
```
src/Main.hs:12:1:
    `Unique' has no constructors (-XEmptyDataDecls permits this)
    In the data type instance declaration for `Unique'
    In the instance declaration for `PersistEntity (BlogPostGeneric backend)'

src/Main.hs:12:1:
    `Unique' has no constructors (-XEmptyDataDecls permits this)
    In the data type instance declaration for `Unique'
    In the instance declaration for `PersistEntity (PersonGeneric backend)'
```
