### PR TITLE
Fix an editing fragment in the book forms chapter

### DIFF
--- a/book/chapters/forms.asciidoc
+++ b/book/chapters/forms.asciidoc
@@ -432,7 +432,7 @@ data Car = Car
 data Color = Red | Blue | Gray | Black
     deriving (Show, Eq, Enum, Bounded)
 
-carAForm :: Maybe Car -> AForm Synopsis Synopsis Car
+carAForm :: Maybe Car -> AForm Handler Car
 carAForm mcar = Car
     <$> areq textField "Model" (carModel <$> mcar)
     <*> areq carYearField "Year" (carYear <$> mcar)


### PR DESCRIPTION
I think there is an editing fragment in the Forms chapter. In the "More sophisticated fields" section, the type signature of the carAForm function changed to: 
carAForm :: Maybe Car -> AForm Synopsis Synopsis Car 
which looks wrong. I think it should be: 
carAForm :: Maybe Car -> AForm Handler Car

or if the type changed on purpose, an explanation about why it changed would be useful. 
