### PR TITLE
Removed `Eq` from Model definition

### DIFF
--- a/book/persistent.asciidoc
+++ b/book/persistent.asciidoc
@@ -1025,7 +1025,7 @@ Person
     name String
     deriving Show
 Car
-    ownerId PersonId Eq
+    ownerId PersonId
     name String
     deriving Show
 |]


### PR DESCRIPTION
Michael Snoyman states here, that it's not needed anymore:
http://stackoverflow.com/questions/14097531/yesod-persistent-field-with-eq
