### PR TITLE
Add missing monadic value to Handler type

### DIFF
--- a/book/routing-and-handlers.asciidoc
+++ b/book/routing-and-handlers.asciidoc
@@ -264,7 +264,7 @@ synonym:
 
 [source, haskell]
 ----
-type Handler = HandlerT MyApp IO
+type Handler = HandlerT MyApp IO ()
 ----
 
 We need to be able to modify the underlying monad when writing subsites, but


### PR DESCRIPTION
I was going through the docs and I noticed that the description of the TH output for WidgetT and HandlerT are different. I'm assuming the version with the monadic value at the end is the correct one, so I appended it at the end.
