### PR TITLE
Add documentation about how the Entity type is defined

### DIFF
--- a/book/persistent.asciidoc
+++ b/book/persistent.asciidoc
@@ -612,7 +612,12 @@ We'll go into more details when we see integration with Yesod.
 +getBy+ is almost identical to +get+, except:
 
 . it takes a uniqueness constraint; that is, instead of an ID it takes a +Unique+ value.
-. it returns an +Entity+ instead of a value. An +Entity+ is a combination of database ID and value.
+. it returns an +Entity+ instead of a value. An +Entity+ is a combination of database ID and value. Essentially:
+
+[source, haskell]
+----
+data Entity b = Entity {entityKey :: Key, entityVal a}
+----
 
 [source, haskell]
 ----


### PR DESCRIPTION
I am never able to remember what an Entity in Persistent consists of (and it was a lot of trouble to figure out in the first place). This pull request is one way that this information could be added to the docs, if you have a better idea of how to include this information, please do that instead, but this is what I could come up with to get the information in there. 
