### PR TITLE
Type in classy-base-prelude; contreversial => controversial

### DIFF
--- a/blog/2014/10/classy-base-prelude.md
+++ b/blog/2014/10/classy-base-prelude.md
@@ -72,7 +72,7 @@ For Haskell to move forward and be as convenient to use as other programming lan
 
 Changing the language so that module qualification is not needed is arguably a much better approach.
 This is the case in Object-Oriented languages, and possible in languages very similar to Haskell such as Frege that figure out how to disambiguate a function based on the data type being used.
-I think this would be a great change to Haskell, but the idea was rejected by Simon Peyton Jones himself during the discussion on fixing Haskell records because it is not compatible with how Haskell's type system operates today. Simon did propose [Type directed name resolution](https://ghc.haskell.org/trac/haskell-prime/wiki/TypeDirectedNameResolution) which I always though was a great idea, but that proposal was not able to get off the ground in part because changing Haskell's dot operator proved too contreversial.
+I think this would be a great change to Haskell, but the idea was rejected by Simon Peyton Jones himself during the discussion on fixing Haskell records because it is not compatible with how Haskell's type system operates today. Simon did propose [Type directed name resolution](https://ghc.haskell.org/trac/haskell-prime/wiki/TypeDirectedNameResolution) which I always though was a great idea, but that proposal was not able to get off the ground in part because changing Haskell's dot operator proved too controversial.
 
 So the only practical option I know of is to focus on #2.
 Being able to write generic code is an important issue in of itself.


### PR DESCRIPTION
Its only a 1 word change; the source diff makes that hard to see. If you look at the [rendered/rich diff](https://github.com/yesodweb/yesodweb.com-content/pull/115/files?short_path=509e076#diff-509e076504d463a6a0bde9ecb54ecc94) its more clear.
