### PR TITLE
Book: Change "exported-modules" to "exposed-modules"

### DIFF
--- a/book/asciidoc/scaffolding-and-the-site-template.asciidoc
+++ b/book/asciidoc/scaffolding-and-the-site-template.asciidoc
@@ -82,7 +82,7 @@ You might be surprised to see the +NoImplicitPrelude+ extension. We turn this
 on since the site includes its own module, +Import+, with a few changes to the
 Prelude that make working with Yesod a little more convenient.
 
-The last thing to note is the exported-modules list. If you add any modules to
+The last thing to note is the exposed-modules list. If you add any modules to
 your application, you *must* update this list to get yesod devel to work
 correctly. Unfortunately, neither Cabal nor GHC will give you a warning if you
 forgot to make this update, and instead you'll get a very scary-looking error


### PR DESCRIPTION
There is a typo in the Scaffolding chapter of the book.

It refers to portion of the cabal file as "exported-modules".
The real name of this section is "exposed-modules".

This commit changes the only mention of "exported-modules" in the chapter.