### PR TITLE
Change cookbook link

### DIFF
--- a/blog/2013/01/adding-css-js.md
+++ b/blog/2013/01/adding-css-js.md
@@ -1,6 +1,6 @@
 _This is a cookbook recipe. Yesod has a strong and growing collection of
 cookbook recipes [available on our
-Wiki](https://github.com/yesodweb/yesod/wiki/Cookbook). If you see any recipes
+Wiki](https://github.com/yesodweb/yesod-cookbook). If you see any recipes
 you think should be highlighted here, or would like to request some additions,
 please bring it up [on the mailing list](groups.google.com/group/yesodweb) or
 [the Google+

--- a/blog/2013/02/ajax-with-scaffold.md
+++ b/blog/2013/02/ajax-with-scaffold.md
@@ -1,7 +1,7 @@
 # Using Ajax with a Scaffolded Site
 
 _This is cookbook recipe, also available from
-[the Wiki](https://github.com/yesodweb/yesod/wiki/Cookbook)._
+[the Wiki](https://github.com/yesodweb/yesod-cookbook)._
 
 A common scenario is that part of an application requires Ajax, while the rest
 is based on dynamically generated HTML.  The core functionality of Yesod
@@ -224,7 +224,7 @@ clipSpecs2 = describe "The clipboard (part 2)" $ do
 
 Actually that is not quite all: for our running example we need to log in in
 each `it` spec.  A recipe for packaging that is the subject of
-[another cookbook article](https://github.com/yesodweb/yesod/wiki/Performing-Authentication-during-Testing).
+[another cookbook article](https://github.com/yesodweb/yesod-cookbook/blob/master/cookbook/Performing-Authentication-during-Testing.md).
 
 ## Appendix: Example handler and client-side code
 

--- a/blog/2013/02/authentication-for-testing.md
+++ b/blog/2013/02/authentication-for-testing.md
@@ -1,7 +1,7 @@
 # Performing Authentication during Testing
 
 _This is cookbook recipe, also available from
-[the Wiki](https://github.com/yesodweb/yesod/wiki/Cookbook)._
+[the Wiki](https://github.com/yesodweb/yesod-cookbook)._
 
 When testing a real application using `Yesod.Test`, each test case may need
 to perform a login.  This is not difficult, but as it involves several steps,

--- a/homepage.html
+++ b/homepage.html
@@ -27,7 +27,7 @@
     <ul>
         <li><a href="/page/quickstart">quick start guide</a></li>
         <li><a href="/book">book</a></li>
-        <li><a href="https://github.com/yesodweb/yesod/wiki/Cookbook">cookbook</a></li>
+        <li><a href="https://github.com/yesodweb/yesod-cookbook">cookbook</a></li>
         <li><a href="/page/community">community</a></li>
         <li><a href="/page/screencasts">screencasts</a></li>
         <li><a href="/blog/2012/04/announcing-yesod-1-0">1.0 release announcement</a></li>

--- a/page/community.html
+++ b/page/community.html
@@ -31,9 +31,9 @@ Title: Community
 <p>If you want to participate with Yesod even more, we have two highly recommended approaches for beginners:</p>
 
 <ul>
-    <li>Work on Wiki documentation, especially <a href="https://github.com/yesodweb/yesod/wiki/Cookbook">the cookbook</a>.</li>
+    <li>Work on Wiki documentation, especially <a href="https://github.com/yesodweb/yesod-cookbook">the cookbook</a>.</li>
     <li>Attack <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+user%3Ayesodweb+label%3Anewcomer+">newcomer issues</a>.</li>
     <li><a href="http://www.yesodweb.com/blog/2012/08/announcing-yesod-1-1">Create add-ons</a>.</li>
 </ul>
 
-<p>If you want to dig into the codebase itself, please check out <a href="https://github.com/organizations/yesodweb/dashboard/issues/repos">the Yesod issue tracker</a> and pick something to work on. If you have any questions, the mailing list are IRC are great places to get some help.</p>
+<p>If you want to dig into the codebase itself, please check out <a href="https://github.com/organizations/yesodweb/dashboard/issues/repos">the Yesod issue tracker</a> and pick something to work on. If you have any questions, the mailing list and IRC are great places to get some help.</p>


### PR DESCRIPTION
Related to this: https://github.com/yesodweb/yesod/issues/1070

The big changes in `homepage.html` is because of Windows file encoding
which is now saved in a UNIX format.