### PR TITLE
Add esqueleto to built libraries

### DIFF
--- a/book/asciidoc/haskell.asciidoc
+++ b/book/asciidoc/haskell.asciidoc
@@ -96,7 +96,7 @@ will install all the libraries you need:
 
 [source, shell]
 ----
-stack build yesod persistent-sqlite yesod-static
+stack build yesod persistent-sqlite yesod-static esqueleto
 ----
 
 In order to run an example from the book, save it in a file, e.g.,


### PR DESCRIPTION
This allows running the SQL joins examples without further installation.