### PR TITLE
Print out to the console the verification email

### DIFF
--- a/book/asciidoc/authentication-and-authorization.asciidoc
+++ b/book/asciidoc/authentication-and-authorization.asciidoc
@@ -266,6 +266,9 @@ users (verify account, password retrieval, etc.).
 Let's have a look at a site that provides email authentication, storing
 passwords in a Persistent SQLite database.
 
+NOTE: Even if you don't have an email server, for debugging purposes the
+verification link is printed in the console.
+
 [source, haskell]
 ----
 {-# LANGUAGE DeriveDataTypeable         #-}
@@ -280,7 +283,7 @@ passwords in a Persistent SQLite database.
 import           Control.Monad            (join)
 import           Control.Monad.Logger (runNoLoggingT)
 import           Data.Maybe               (isJust)
-import           Data.Text                (Text)
+import           Data.Text                (Text, unpack)
 import qualified Data.Text.Lazy.Encoding
 import           Data.Typeable            (Typeable)
 import           Database.Persist.Sqlite
@@ -353,7 +356,12 @@ instance YesodAuthEmail App where
     addUnverified email verkey =
         runDB $ insert $ User email Nothing (Just verkey) False
 
-    sendVerifyEmail email _ verurl =
+    sendVerifyEmail email _ verurl = do
+        -- Print out to the console the verification email, for easier
+        -- debugging.
+        liftIO $ putStrLn $ "Copy/ Paste this URL in your browser:" ++ unpack verurl
+
+        -- Send email.
         liftIO $ renderSendMail (emptyMail $ Address Nothing "noreply")
             { mailTo = [Address Nothing email]
             , mailHeaders =


### PR DESCRIPTION
Following the email registration example, I have no email server on my local (best way to prevent accidental emails :wink: ) - but I still wanted to see the `verurl` one gets.

This PR is an attempt at adding the `verurl` to the console. I assume there's a better way to print, but `liftIO $ print "Copy/ Paste this URL in your browser:" $ unpack verurl` doesn't seem to work.

![book_ _stack_runhaskell_example_hs_ _ghc_ _121x29](https://cloud.githubusercontent.com/assets/125707/12532078/7fb96748-c213-11e5-87ab-50abbaef1d5f.jpg)
