### PR TITLE
Fixed stack download url in quickstart

### DIFF
--- a/page/quickstart.md
+++ b/page/quickstart.md
@@ -2,7 +2,7 @@ Title: Yesod quick start guide
 
 The Yesod team strongly recommends using [the stack build tool](https://github.com/commercialhaskell/stack#readme) for developing with stack. There are other build tools available in the Haskell world which will likely work with Yesod, but stack provides the easiest experience. To get started:
 
-1. Follow the [installation instructions for stack](https://github.com/commercialhaskell/stack/wiki/Downloads) to get stack.
+1. Follow the [installation instructions for stack](http://docs.haskellstack.org/en/stable/install_and_upgrade.html) to get stack.
 2. Create a new scaffolded site: `stack new my-project yesod-sqlite && cd my-project`
     * NOTE: Use `stack templates` to see other available Yesod scaffoldings.
 3. Install the yesod command line tool: `stack install yesod-bin cabal-install --install-ghc`


### PR DESCRIPTION
Because the page under old url says that the page has been moved. So we prevent the user for a further click.