### PR TITLE
Fix typo in hash fragments example.

### DIFF
--- a/book/asciidoc/routing-and-handlers.asciidoc
+++ b/book/asciidoc/routing-and-handlers.asciidoc
@@ -611,11 +611,11 @@ getHomeR = defaultLayout $ do
     setTitle "Redirects"
     [whamlet|
         <p>
-            <a href=@{Link1R}>Click to start the redirect loop!
+            <a href=@{Link1R}>Click to start the redirect chain!
     |]
 
 getLink1R, getLink2R, getLink3R :: Handler ()
-getLink1R = redirect Link2R -- /link1
+getLink1R = redirect Link2R -- /link2
 getLink2R = redirect (Link3R, [("foo", "bar")]) -- /link3?foo=bar
 getLink3R = redirect $ Link4R :#: ("baz" :: Text) -- /link4#baz
 


### PR DESCRIPTION
The comment after the redirect from Link1 to Link2 was incorrect. The link text in the home handler has also been changed to read "redirect chain" instead of "redirect loop" since it's not really a loop.