### PR TITLE
Correction of stack command and cosmetic small changes

### DIFF
--- a/book/asciidoc/scaffolding-and-the-site-template.asciidoc
+++ b/book/asciidoc/scaffolding-and-the-site-template.asciidoc
@@ -26,8 +26,8 @@ information in this chapter is slightly outdated.
 
 The yesod-bin package installs an executable (conveniently named
 _yesod_ as well). This executable provides a few commands (run _stack
-exec -- yesod --help_ to get a list). In order to generate a
-scaffolding, the command is _stack new my-project
+exec \-- yesod --help_ to get a list). In order to generate a
+scaffolding, the command is _stack new my-project 
 yesod-postgres_. This will generate a scaffolding site with a postgres
 database backend in a directory named +my-project+. You can see the
 other available templates using the command *stack templates*.
@@ -42,11 +42,11 @@ scaffoldings for one of the database backends. There will be minor
 differences for the yesod-simple backend.
 
 After creating your files, install the yesod command line tool inside
-the project: *stack build yesod-bin cabal-install*. Then do a *stack
+the project: *stack install yesod-bin cabal-install*. Then do a *stack
 build* inside the directory.  In particular, the commands provided
 will ensure that any missing dependencies are built and installed.
 
-Finally, to launch your development site, you would use +stack exec --
+Finally, to launch your development site, you would use +stack exec \--
 yesod devel+.  This site will automatically rebuild and reload
 whenever you change your code.
 
@@ -58,7 +58,7 @@ well.
 
 ==== Cabal file
 
-Whether directly using +stack+, or indirectly using +stack exec -- yesod devel+, building
+Whether directly using +stack+, or indirectly using +stack exec \-- yesod devel+, building
 your code will always go through the cabal file. If you open the file, you'll
 see that there are both library and executable blocks. If the +library-only+
 flag is turned on, then the executable block is not built.  This is how +yesod


### PR DESCRIPTION
Corrected the stack command  to install yesod bin and caball install and inserted some escapes to avoid the render of a big dash instead of "--" (two hyfens) on commands syntax.