### PR TITLE
Fixes user error of pasting commented line in .lucius file

### DIFF
--- a/book/asciidoc/shakespearean-templates.asciidoc
+++ b/book/asciidoc/shakespearean-templates.asciidoc
@@ -830,7 +830,7 @@ main = TLIO.putStrLn $ renderCss $ template render
 
 [source, lucius]
 ----
--- @template.lucius
+/* @template.lucius */
 foo { bar: baz }
 ----
 


### PR DESCRIPTION
I think the issue at found the issue at https://github.com/yesodweb/yesodweb.com-content/issues/88 is similar to mine.

Ran into similar issue, 

```
$ stack runghc test.hs 
test2.hs:20:12: error:
    • Exception when trying to run compile-time code:
        "-- @template.lucius
foo { bar: baz }" (line 1, column 1):
unexpected " "
expecting "-->"
CallStack (from HasCallStack):
  error, called at ./Text/Css.hs:136:17 in shakespeare-2.0.12.1-7zylhH6EvxxByWoabG0aiC:Text.Css
      Code: luciusFileDebug "template.lucius"
    • In the untyped splice: $(luciusFileDebug "template.lucius")
```