### PR TITLE
fix compile error

### DIFF
--- a/book/asciidoc/yesod-for-haskellers.asciidoc
+++ b/book/asciidoc/yesod-for-haskellers.asciidoc
@@ -314,7 +314,7 @@ instance RenderRoute App where
                         )
 
 instance YesodDispatch App where
-    yesodDispatch (YesodRunnerEnv _logger site _sessionBackend _) _req sendResponse =
+    yesodDispatch (YesodRunnerEnv _logger site _sessionBackend _ _) _req sendResponse =
         sendResponse $ responseBuilder
             status200
             [("Content-Type", "text/html")]


### PR DESCRIPTION
```

    • The constructor ‘YesodRunnerEnv’ should have 5 arguments, but has been given 4
    • In the pattern: YesodRunnerEnv _logger site _sessionBackend _
      In an equation for ‘yesodDispatch’:
          yesodDispatch
            (YesodRunnerEnv _logger site _sessionBackend _)
            _req
            sendResponse
            = sendResponse
                $ responseBuilder
                    status200
                    [("Content-Type", "text/html")]
                    (renderHtmlBuilder $ welcomeMessage site)
      In the instance declaration for ‘YesodDispatch App’
   |
29 |   yesodDispatch (YesodRunnerEnv _logger site _sessionBackend _) _req sendResponse =
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```