### PR TITLE
Updated link to Persistent Entity Syntax documentation

### DIFF
--- a/book/asciidoc/persistent.asciidoc
+++ b/book/asciidoc/persistent.asciidoc
@@ -1620,4 +1620,4 @@ helper packages like +yesod-persistent+ provide a nice layer, but packages like
 +yesod-form+ and +yesod-auth+ also leverage Persistent's features as well.
 
 For more information on the syntax of entity declarations, database connection, etc.
-Checkout https://github.com/yesodweb/persistent/wiki
+Checkout https://github.com/yesodweb/persistent/tree/master/docs

--- a/book/asciidoc/persistent.asciidoc
+++ b/book/asciidoc/persistent.asciidoc
@@ -1094,8 +1094,7 @@ Person sql=the-person-table id=numeric_id
 
 There are a number of other features to the entity definition syntax. An
 up-to-date list is maintained
-link:https://github.com/yesodweb/yesod/wiki/Persistent-entity-syntax[on the
-Yesod wiki].
+link:https://github.com/yesodweb/persistent/blob/master/docs/Persistent-entity-syntax.md[in the Persistent documentation].
 
 === Relations
 


### PR DESCRIPTION
Link to 'Persistent Entity Syntax' documentation in the Persistent chapter of the book was out of date. Updated to point to the correct page. Also updated documentation link at the end of the chapter.