### PR TITLE
Added warning about not using automated migrations in production

### DIFF
--- a/book/asciidoc/persistent.asciidoc
+++ b/book/asciidoc/persistent.asciidoc
@@ -38,7 +38,8 @@ declarative syntax. Some other nice features are:
   An additional library, link:http://hackage.haskell.org/package/esqueleto[Esqueleto],
   builds on top of the Persistent data model, adding type-safe joins and SQL functionality.
 
-* Automatically perform database migrations
+* Automatic database migrations in non-production environments to speed up
+  development.
 
 Persistent works well with Yesod, but it is quite
 usable on its own as a standalone library. Most of this chapter will address
@@ -458,6 +459,12 @@ main = runSqlite ":memory:" $ do
 With this one little code change, Persistent will automatically create your
 +Person+ table for you. This split between +runMigration+ and +migrate+ allows
 you to migrate multiple tables simultaneously.
+
+NOTE: Using automated database migrations is only recommended in development
+environments. Allowing your application to modify your database schema in
+a production environment is _very strongly discouraged_. Automated migrations
+can be used to help speed up development, but are not a replacement for manual
+review and testing that should take place before production deployments.
 
 This works when dealing with just a few entities, but can quickly get tiresome
 once we are dealing with a dozen entities. Instead of repeating yourself,


### PR DESCRIPTION
Based off of a discussion with @bitemyapp in the Haskell Slack channel, added disclaimer to not use automated database migrations in production environments.