### PR TITLE
Update restful-content.asciidoc

### DIFF
--- a/book/asciidoc/restful-content.asciidoc
+++ b/book/asciidoc/restful-content.asciidoc
@@ -302,7 +302,7 @@ main :: IO ()
 main = warp 3000 App
 ----
 
-+provideJson+ is similarly trivial, in this case +provideRep . returnJson+.
++provideJson+ is similarly trivial, in this case +provideRep . return . toEncoding+.
 
 ==== New datatypes
 


### PR DESCRIPTION
`provideJson` is defined as below;

```haskell
-- | Provide a JSON representation for usage with 'selectReps', using aeson\'s
-- 'J.toJSON' (aeson >= 0.11: 'J.toEncoding') function to perform the conversion.
--
-- @since 1.2.1
provideJson :: (Monad m, J.ToJSON a) => a -> Writer (Endo [ProvidedRep m]) ()
provideJson = provideRep . return . J.toEncoding
```

https://www.stackage.org/haddock/lts-12.10/yesod-core-1.6.6/src/Yesod.Core.Json.html#provideJson