### PR TITLE
book/auth: reset verkey in verifyAccount

### DIFF
--- a/book/asciidoc/authentication-and-authorization.asciidoc
+++ b/book/asciidoc/authentication-and-authorization.asciidoc
@@ -371,7 +371,7 @@ instance YesodAuthEmail App where
         case mu of
             Nothing -> return Nothing
             Just u -> do
-                update uid [UserVerified =. True]
+                update uid [UserVerified =. True, UserVerkey =. Nothing]
                 return $ Just uid
     getPassword = liftHandler . runDB . fmap (join . fmap userPassword) . get
     setPassword uid pass = liftHandler . runDB $ update uid [UserPassword =. Just pass]


### PR DESCRIPTION
Maybe I'm misunderstanding [the api docs](https://www.stackage.org/haddock/lts-13.25/yesod-auth-1.6.6/Yesod-Auth-Email.html#v:verifyAccount) but this seems to be what they suggest. See also yesodweb/yesod-cookbook#44.