### PR TITLE
Fix broken use of Network.Mail.Mime

### DIFF
--- a/book/asciidoc/authentication-and-authorization.asciidoc
+++ b/book/asciidoc/authentication-and-authorization.asciidoc
@@ -340,8 +340,8 @@ instance YesodAuthEmail App where
         textPart = Part
             { partType = "text/plain; charset=utf-8"
             , partEncoding = None
-            , partFilename = Nothing
-            , partContent = Data.Text.Lazy.Encoding.encodeUtf8
+            , partDisposition = DefaultDisposition
+            , partContent = PartContent $ Data.Text.Lazy.Encoding.encodeUtf8
                 [stext|
                     Please confirm your email address by clicking on the link below.
 
@@ -354,8 +354,8 @@ instance YesodAuthEmail App where
         htmlPart = Part
             { partType = "text/html; charset=utf-8"
             , partEncoding = None
-            , partFilename = Nothing
-            , partContent = renderHtml
+            , partDisposition = DefaultDisposition
+            , partContent = PartContent $ renderHtml
                 [shamlet|
                     <p>Please confirm your email address by clicking on the link below.
                     <p>


### PR DESCRIPTION
Updated the example code to be in line with current version of the Network.Mail.Mime library as per http://hackage.haskell.org/package/mime-mail-0.5.0/docs/Network-Mail-Mime.html#t:Part