### PR TITLE
Fix reversed explanation on insertBy

### DIFF
--- a/book/asciidoc/authentication-and-authorization.asciidoc
+++ b/book/asciidoc/authentication-and-authorization.asciidoc
@@ -309,8 +309,8 @@ instance YesodAuth App where
         x <- insertBy $ User (credsIdent creds) Nothing Nothing False
         return $ Authenticated $
             case x of
-                Left (Entity userid _) -> userid -- newly added user
-                Right userid -> userid -- existing user
+                Left (Entity userid _) -> userid -- existing user
+                Right userid -> userid -- newly added user
 
 instance YesodAuthPersist App
 


### PR DESCRIPTION
insertBy left and right were switched around, the opposite of https://hackage.haskell.org/package/persistent-2.10.1/docs/src/Database.Persist.Class.PersistUnique.html#insertBy