### PR TITLE
changed `yesodweb-*` to `yesod-*` on quickstart and scaffolding page;…

### DIFF
--- a/book/asciidoc/scaffolding-and-the-site-template.asciidoc
+++ b/book/asciidoc/scaffolding-and-the-site-template.asciidoc
@@ -27,7 +27,7 @@ information in this chapter is slightly outdated.
 The yesod-bin package installs an executable (conveniently named _yesod_ as
 well). This executable provides a few commands (run +stack exec \-- yesod
 --help+ to get a list). In order to generate a scaffolding, the command is
-+stack new my-project yesodweb/postgres && cd my-project+. This will generate a
++stack new my-project yesod-postgres && cd my-project+. This will generate a
 scaffolding site with a postgres database backend in a directory named
 +my-project+. You can see the other available templates using the command
 *stack templates*.

--- a/page/quickstart.md
+++ b/page/quickstart.md
@@ -2,7 +2,7 @@ Title: Yesod quick start guide
 
 1. Follow the [FP Complete get started guide](https://haskell.fpcomplete.com/get-started) to get the Stack build tool.
     * On POSIX systems, this is usually `curl -sSL https://get.haskellstack.org/ | sh`
-2. Create a new scaffolded site: `stack new my-project yesodweb/sqlite && cd my-project`
+2. Create a new scaffolded site: `stack new my-project yesod-sqlite && cd my-project`
     * NOTE: You can see [other template options on Github](https://github.com/yesodweb/stack-templates).
 3. Install the yesod command line tool: `stack install yesod-bin --install-ghc`
 4. Build libraries: `stack build`


### PR DESCRIPTION
… former command doesn't work with stack version 1.9.3; see [this reddit discussion](https://www.reddit.com/r/haskell/comments/fuqwvm/yesod_scaffolding_problem/)

used ` grep -iR "[^(http.*/)]yesodweb/" .` to find occurrences of the command in the repo.