### PR TITLE
Typo

### DIFF
--- a/book/asciidoc/shakespearean-templates.asciidoc
+++ b/book/asciidoc/shakespearean-templates.asciidoc
@@ -356,7 +356,7 @@ special treatment for IDs and classes. For example, the Hamlet snippet:
 
 [source, hamlet]
 ----
-<p #firstid>Paragraph <i #secondid>italic end.
+<p #firstid>Paragraph <i #secondid>italic</i> end.
 ----
 
 generates the HTML:


### PR DESCRIPTION
Please review, but I believe this is what was meant, else I can't figure why a word would be magically selected instead of anything else.