### PR TITLE
fixed port inconsistency in code snippet

### DIFF
--- a/book/asciidoc/widgets.asciidoc
+++ b/book/asciidoc/widgets.asciidoc
@@ -177,7 +177,7 @@ getHomeR = defaultLayout $ do
         [hamlet|<script src=/included-in-head.js>|]
 
 main :: IO ()
-main = warp 3001 App
+main = warp 3000 App
 ----
 
 Note that even though +toWidgetHead+ was called after +toWidgetBody+, the


### PR DESCRIPTION
A simple typo fix.
Up until this code snippet all code has used port 3000. This code snippet uses port 3001. A reader might be confused if they use this code snippet and wonder why their browser isn't finding their website anymore.