### PR TITLE
Replace `ToHtml` with `ToMarkup`

### DIFF
--- a/book/asciidoc/shakespearean-templates.asciidoc
+++ b/book/asciidoc/shakespearean-templates.asciidoc
@@ -391,7 +391,7 @@ You can apply functions within an interpolation. You can use string and numeric
 literals in an interpolation. You can use qualified modules. Both parentheses
 and the dollar sign can be used to group statements together. And at the end,
 the +toHtml+ function is applied to the result, meaning _any_ instance of
-+ToHtml+ can be interpolated. Take, for instance, the following code.
++ToMarkup+ can be interpolated. Take, for instance, the following code.
 
 [source, haskell]
 ----

--- a/book/generated-xml/shakespearean-templates.xml
+++ b/book/generated-xml/shakespearean-templates.xml
@@ -311,7 +311,7 @@ pass variables in.</simpara>
 literals in an interpolation. You can use qualified modules. Both parentheses
 and the dollar sign can be used to group statements together. And at the end,
 the <literal>toHtml</literal> function is applied to the result, meaning <emphasis>any</emphasis> instance of
-<literal>ToHtml</literal> can be interpolated. Take, for instance, the following code.</simpara>
+<literal>ToMarkup</literal> can be interpolated. Take, for instance, the following code.</simpara>
 <programlisting language="haskell" linenumbering="unnumbered">-- Just ignore the quasiquote stuff for now, and that shamlet thing.
 -- It will be explained later.
 {-# LANGUAGE QuasiQuotes #-}


### PR DESCRIPTION
I believe the type class that we need to be referencing is [ToMarkup](https://www.stackage.org/haddock/lts-16.26/blaze-markup-0.8.2.7/Text-Blaze.html#t:ToMarkup). This would be consistent with the rest of the document's mention of `blase-html`.

P.S. I think the reason for the error is that we have a type synonym `type Html = Markup`