### PR TITLE
Move splices before instance declarations

### DIFF
--- a/book/asciidoc/internationalization.asciidoc
+++ b/book/asciidoc/internationalization.asciidoc
@@ -69,16 +69,16 @@ plural _ _ y = y
 showInt :: Int -> String
 showInt = show
 
-instance Yesod App
-
-instance RenderMessage App FormMessage where
-    renderMessage _ _ = defaultFormMessage
-
 mkYesod "App" [parseRoutes|
 /     HomeR GET
 /buy  BuyR  GET
 /lang LangR POST
 |]
+
+instance Yesod App
+
+instance RenderMessage App FormMessage where
+    renderMessage _ _ = defaultFormMessage
 
 getHomeR :: Handler Html
 getHomeR = defaultLayout

--- a/book/asciidoc/routing-and-handlers.asciidoc
+++ b/book/asciidoc/routing-and-handlers.asciidoc
@@ -385,13 +385,14 @@ import qualified Data.Text as T
 import           Yesod
 
 data App = App
-instance Yesod App
 
 mkYesod "App" [parseRoutes|
 /person/#Text PersonR GET
 /year/#Integer/month/#Text/day/#Int DateR
 /wiki/*Texts WikiR GET
 |]
+
+instance Yesod App
 
 getPersonR :: Text -> Handler Html
 getPersonR name = defaultLayout [whamlet|<h1>Hello #{name}!|]
@@ -546,15 +547,16 @@ import           Control.Monad     (when)
 import           Yesod
 
 data App = App
+
+mkYesod "App" [parseRoutes|
+/ HomeR GET
+|]
+
 instance Yesod App where
     -- This function controls which messages are logged
     shouldLogIO App src level =
         return True -- good for development
         -- level == LevelWarn || level == LevelError -- good for production
-
-mkYesod "App" [parseRoutes|
-/ HomeR GET
-|]
 
 getHomeR :: Handler Html
 getHomeR = do

--- a/book/asciidoc/sql-joins.asciidoc
+++ b/book/asciidoc/sql-joins.asciidoc
@@ -58,17 +58,18 @@ data App = App
     { persistConfig :: SqliteConf
     , connPool      :: ConnectionPool
     }
+
+mkYesod "App" [parseRoutes|
+/ HomeR GET
+/blog/#BlogId BlogR GET
+|]
+
 instance Yesod App
 instance YesodPersist App where
     type YesodPersistBackend App = SqlBackend
     runDB = defaultRunDB persistConfig connPool
 instance YesodPersistRunner App where
     getDBRunner = defaultGetDBRunner connPool
-
-mkYesod "App" [parseRoutes|
-/ HomeR GET
-/blog/#BlogId BlogR GET
-|]
 
 getHomeR :: Handler Html
 getHomeR = do
@@ -396,17 +397,18 @@ data App = App
     { persistConfig :: SqliteConf
     , connPool      :: ConnectionPool
     }
+
+mkYesod "App" [parseRoutes|
+/ HomeR GET
+/blog/#BlogId BlogR GET
+|]
+
 instance Yesod App
 instance YesodPersist App where
     type YesodPersistBackend App = SqlBackend
     runDB = defaultRunDB persistConfig connPool
 instance YesodPersistRunner App where
     getDBRunner = defaultGetDBRunner connPool
-
-mkYesod "App" [parseRoutes|
-/ HomeR GET
-/blog/#BlogId BlogR GET
-|]
 
 getHomeR :: Handler TypedContent
 getHomeR = do

--- a/book/asciidoc/yesod-for-haskellers.asciidoc
+++ b/book/asciidoc/yesod-for-haskellers.asciidoc
@@ -913,12 +913,12 @@ import           Yesod.Core (RenderRoute (..), Yesod, mkYesod, parseRoutes,
 -- | Our foundation datatype.
 data App = App
 
-instance Yesod App
-
 mkYesod "App" [parseRoutes|
 /         HomeR GET
 /fib/#Int FibR  GET
 |]
+
+instance Yesod App
 
 getHomeR :: Handler ()
 getHomeR = redirect (FibR 1)


### PR DESCRIPTION
As of GHC 9.0.1, the mkYesod splice needs to be before the Yesod instance.