### PR TITLE
Fix documentation about default value of approot

### DIFF
--- a/book/asciidoc/yesod-typeclass.asciidoc
+++ b/book/asciidoc/yesod-typeclass.asciidoc
@@ -72,9 +72,8 @@ construct a URL for +SomePathR+, it determines that the relative path for
 +SomePathR+ is +/some/path+, appends that to your approot and creates
 +http://static.example.com/wiki/some/path+.
 
-The default value of +approot+ is +ApprootRelative+, which essentially means
-``don't add any prefix.'' In that case, the generated URL would be
-+/some/path+. This works fine for the common case of a link within your
+The default value of +approot+ is +guessApproot+.
+This works fine for the common case of a link within your
 application, and your application being hosted at the root of your domain. But
 if you have any use cases which demand absolute URLs (such as sending an
 email), it's best to use +ApprootStatic+.


### PR DESCRIPTION
I tried regenerating the docs, but it's crashing for me:

    $ book/tools/generate.sh
    ...
    + [[ /home/jeremy/src/github.com/yesodweb/yesodweb.com-content/book/tools/../asciidoc/yesod-typeclass.asciidoc -nt /home/jeremy/src/github.com/yesodweb/yesodweb.com-content/book/tools/../generated-xml/yesod-typeclass.xml ]]
    + asciidoc -b docbook45 --attribute=idprefix=yesod-typeclass_ -o tmp /home/jeremy/src/github.com/yesodweb/yesodweb.com-content/book/tools/../asciidoc/yesod-typeclass.asciidoc
    + /home/jeremy/src/github.com/yesodweb/yesodweb.com-content/book/tools/strip-article-info.hs tmp
    Could not parse '/home/jeremy/.stack/global-project/stack.yaml':
    AesonException "Error in $.resolver: failed to parse field 'resolver': failed to parse field resolver: failed to parse field 'name': key \"name\" not present"
    See http://docs.haskellstack.org/en/stable/yaml_configuration/.

I then stumbled on
https://www.yesodweb.com/blog/2016/01/auto-generate-docbook-xml, which makes it sound like this is (used to be?) automated by travis. So I'm not sure if any action is really required here. (Side note: this repo might benefit from a `CONTRIBUTING.md` file!)

This fixes https://github.com/yesodweb/yesodweb.com-content/issues/270