### PR TITLE
Add documentation for special case of empty args

### DIFF
--- a/book/asciidoc/routing-and-handlers.asciidoc
+++ b/book/asciidoc/routing-and-handlers.asciidoc
@@ -182,6 +182,32 @@ One issue that overlapping routes introduce is ambiguity. In the example above,
 should +/foo/bar+ route to +Foo1R+ or +Foo3R+? And should +/foo/42+ route to
 +Foo2R+ or +Foo3R+? Yesod's rule for this is simple: first route wins.
 
+===== Empty +#String+ or +#Text+ as dynamic piece
+
+How to pass the empty string to routes with +#String+ or +#Text+ pieces?
+
+Consider the following route declaration:
+
+[source, routes]
+----
+/hello          HomeR  GET
+/hello/#String  HelloR GET
+----
+
+In URLs we cannot simply pass the empty string (+""+) for a dynamic path piece like in +/hello/#String+.
+Yesod's dispatch mechanism would instead use +HomeR+ for an empty string because it
+always redirects to the canonical form of the URL
+(see section <<_pieces>>).
+
+This is why Yesod puts a Minus sign (+-+) in the URL for +@{HelloR ""}+.
+The resulting URL would be +/hello/-+.
+The handler function +getHelloR :: String -> Handler Html+ will still receive the empty string.
+
+Also, to disambiguate a single actual +-+ in the URL, Yesod prefixes that piece with another Minus sign.
+Consequently, Yesod also prefixes any string consisting only of Minus signs with one single Minus sign.
+
+This applies for +#String+ and +#Text+ pieces as well.
+
 ==== Resource name
 
 Each resource pattern also has a name associated with it. That name will become

--- a/book/asciidoc/routing-and-handlers.asciidoc
+++ b/book/asciidoc/routing-and-handlers.asciidoc
@@ -203,7 +203,7 @@ instead. Yesod automatically converts the Minus sign to the empty string.
 
 Likewise, the resulting URL for +@{HelloNameR ""}+ would be +/hello/-+.
 
-Also, to disambiguate a single actual +-+ in the URL, Yesod prefixes that piece with another Minus sign.
+Also, to disambiguate a single actual +-+, Yesod prefixes that piece with another Minus sign when rendering the URL.
 Consequently, Yesod also prefixes any string consisting only of Minus signs with one single Minus sign.
 
 NOTE: This conversion between empty string in Haskell and +-+ in the

--- a/book/asciidoc/routing-and-handlers.asciidoc
+++ b/book/asciidoc/routing-and-handlers.asciidoc
@@ -184,29 +184,30 @@ should +/foo/bar+ route to +Foo1R+ or +Foo3R+? And should +/foo/42+ route to
 
 ===== Empty +#String+ or +#Text+ as dynamic piece
 
-How to pass the empty string to routes with +#String+ or +#Text+ pieces?
-
 Consider the following route declaration:
 
 [source, routes]
 ----
-/hello          HomeR  GET
-/hello/#String  HelloR GET
+/hello          HelloR     GET
+/hello/#String  HelloNameR GET
 ----
 
-In URLs we cannot simply pass the empty string (+""+) for a dynamic path piece like in +/hello/#String+.
-Yesod's dispatch mechanism would instead use +HomeR+ for an empty string because it
-always redirects to the canonical form of the URL
-(see section <<_pieces>>).
+Let's say a user requests the path +/hello/+ – which handler would respond to the request?
 
-This is why Yesod puts a Minus sign (+-+) in the URL for +@{HelloR ""}+.
-The resulting URL would be +/hello/-+.
-The handler function +getHelloR :: String -> Handler Html+ will still receive the empty string.
+It will be +HelloR+ because Yesod's dispatch mechanism removes trailing slashes and
+redirects to the canonical form of the URL (see section <<_pieces>>).
+
+If users actually want to address the +HelloNameR+ handler with an
+empty string as argument they need to request the path +/hello/-+
+instead. Yesod automatically converts the Minus sign to the empty string.
+
+Likewise, the resulting URL for +@{HelloNameR ""}+ would be +/hello/-+.
 
 Also, to disambiguate a single actual +-+ in the URL, Yesod prefixes that piece with another Minus sign.
 Consequently, Yesod also prefixes any string consisting only of Minus signs with one single Minus sign.
 
-This applies for +#String+ and +#Text+ pieces as well.
+NOTE: This conversion between empty string in Haskell and +-+ in the
+URL applies for +#String+ and +#Text+ pieces as well.
 
 ==== Resource name
 


### PR DESCRIPTION
Hi there, I recently stumbled upon the question how Yesod handles empty strings like in `@{MyRouteR ""}`.

First, the behavior was quite irritating for me, then I understood the logic behind.

I documented it and thought it might fit well in the book chapter on routes?

What do you think?

In my case, I deliberately wanted pass `""` in `/orders/#Text`. I wanted to use query string args – submitted through a form with `method=get` – to redirect from `/orders/-?order_number=123456` to `/orders/123456`.