### PR TITLE
Update Persistent language extensions in Person table code example

### DIFF
--- a/book/asciidoc/persistent.asciidoc
+++ b/book/asciidoc/persistent.asciidoc
@@ -337,6 +337,8 @@ pass it off to other Persistent functions.
 {-# LANGUAGE QuasiQuotes                #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE FlexibleInstances          #-}
 
 import           Control.Monad.IO.Class  (liftIO)
 import           Database.Persist


### PR DESCRIPTION
I'm getting the following error when building the Person code snippet. Adding the recommended two lines makes the program compile on my system.
```
derek persistent-demo % stack build

Warning: Stack has not been tested with GHC versions above 9.6, and using 9.6.4, this may fail.

Warning: Stack has not been tested with Cabal versions above 3.10, but version 3.10.1.0 was found, this may fail.
persistent-demo> configure (lib + exe)
Configuring persistent-demo-0.1.0.0...
persistent-demo> build (lib + exe)
Preprocessing library for persistent-demo-0.1.0.0..
Building library for persistent-demo-0.1.0.0..
[1 of 2] Compiling Lib
[2 of 2] Compiling Paths_persistent_demo
Preprocessing executable 'persistent-demo-exe' for persistent-demo-0.1.0.0..
Building executable 'persistent-demo-exe' for persistent-demo-0.1.0.0..
[1 of 2] Compiling Main [Source file changed]

[2 of 2] Compiling Paths_persistent_demo [Source file changed]
/Users/derek.ye/learning/haskell/persistent-demo/app/Main.hs:24:1: error: [GHC-39584]
    Generating Persistent entities now requires the following language extensions:

StandaloneDeriving
FlexibleInstances

Please enable the extensions by copy/pasting these lines into the top of your file:

{-# LANGUAGE StandaloneDeriving #-}
{-# LANGUAGE FlexibleInstances #-}
   |
24 | share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...

Error: [S-7282]
       Stack failed to execute the build plan.
       
       While executing the build plan, Stack encountered the error:
       
       [S-7011]
       While building package persistent-demo-0.1.0.0 (scroll up to its section to see the error) using:
```